### PR TITLE
Reset values onCancel and lock gap when xrp and eth

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@angular/language-service": "^4.4.7",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
-    "@types/lodash": "^4.14.71",
-    "@types/node": "~6.0.60",
+    "@types/lodash": "4.14.109",
+    "@types/node": "^14.14.20",
     "codelyzer": "~3.0.1",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
@@ -53,6 +53,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
-    "typescript": "^2.6.2"
+    "typescript": "^4.1.3"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -89,7 +89,7 @@
 
           <div class="form-group col-sm-3 col-xs-12">
             <label for="addressGap">Address Gap*</label>
-            <input type="number" min="0" class="form-control" id="addressGap" name="addressGap" [(ngModel)]="addressGap" required>
+            <input type="number" min="0" class="form-control" id="addressGap" name="addressGap"  disabled="{{disableGapChange}}" [(ngModel)]="addressGap" required>
           </div>
           <div class="form-group col-sm-3 col-xs-12">
             <label for="account">Account*</label>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,6 +15,7 @@ export class AppComponent implements OnInit {
   public signaturesNumber: number; // m
   public copayersNumber: number; // n
   public chain: string;
+  public disableGapChange: boolean;
   public network: string;
   public coin: string;
   public addressGap: number;
@@ -50,6 +51,7 @@ export class AppComponent implements OnInit {
     private recoveryService: RecoveryService
   ) {
     this.addressGap = 20;
+    this.disableGapChange = false;
     this.account = 0;
     this.data = {
       backUp: [],
@@ -105,6 +107,9 @@ export class AppComponent implements OnInit {
     this.beforeScan = true;
     this.recoveryService.stopSearching = false;
     this.showXrpLockedInfo = false;
+    this.reportInactive = '0';
+    this.reportAddresses = '0';
+    this.reportXrpLocked = null;
 
     const inputs = _.map(_.range(1, this.copayersNumber + 1), (i) => {
       return {
@@ -135,7 +140,7 @@ export class AppComponent implements OnInit {
       this.coin = 'btc';
       this.fee = 0.001;
     }
-
+    this.reportAmount = '0 ' + this.coin.toLocaleUpperCase();
     try {
       this.wallet = this.recoveryService.getWallet(inputs, this.signaturesNumber, this.copayersNumber, this.coin, this.network);
     } catch (ex) {
@@ -314,11 +319,13 @@ export class AppComponent implements OnInit {
   }
 
   public updateAddressGap(): void {
+    this.disableGapChange = false;
     switch (this.chain) {
       case 'xrp/livenet':
       case 'xrp/testnet':
       case 'eth/livenet':
         this.addressGap = 1;
+        this.disableGapChange = true;
         break;
       default:
         this.addressGap = 20;


### PR DESCRIPTION
Add few things:
- reset some values when cancel a previous operation
- lock change of gap when XPR and ETH (always 1 - avoid unnecessary requests)